### PR TITLE
Add conditional branching support for workflow execution

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,10 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="5a384825-87f7-4752-bb95-dcf8d7a51e56" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/playbook/cli/commands/run.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/playbook/cli/commands/run.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/playbook/domain/models.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/playbook/domain/models.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/playbook/infrastructure/parser.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/playbook/infrastructure/parser.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/playbook/service/engine.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/playbook/service/engine.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -44,7 +47,7 @@
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
     "SHARE_PROJECT_CONFIGURATION_FILES": "true",
-    "git-widget-placeholder": "main",
+    "git-widget-placeholder": "feat/conditional",
     "last_opened_file_path": "/Users/Q187392/dev/s/private/playbook",
     "node.js.detected.package.eslint": "true",
     "node.js.detected.package.tslint": "true",
@@ -241,12 +244,12 @@
       <breakpoints>
         <line-breakpoint enabled="true" suspend="THREAD" type="python-line">
           <url>file://$PROJECT_DIR$/src/playbook/service/engine.py</url>
-          <line>488</line>
+          <line>575</line>
           <option name="timeStamp" value="4" />
         </line-breakpoint>
         <line-breakpoint enabled="true" suspend="THREAD" type="python-line">
           <url>file://$PROJECT_DIR$/src/playbook/service/engine.py</url>
-          <line>194</line>
+          <line>260</line>
           <option name="timeStamp" value="5" />
         </line-breakpoint>
       </breakpoints>

--- a/examples/conditional_dependencies.playbook.toml
+++ b/examples/conditional_dependencies.playbook.toml
@@ -1,0 +1,60 @@
+# Conditional Dependencies Syntax Example
+# This example demonstrates the shorthand conditional dependency syntax
+
+[runbook]
+title = "Conditional Dependencies Example"
+description = "Demonstrates conditional dependency syntax (node_id:success/failure)"
+version = "1.0.0"
+author = "devops-team"
+created_at = "2025-01-20T12:00:00Z"
+
+# Build step (always runs first)
+[build]
+type = "Command"
+command_name = "make build"
+description = "Build the application"
+depends_on = []
+
+# Test step (depends on build completing)
+[test]
+type = "Command"
+command_name = "make test"
+description = "Run tests"
+depends_on = ["build"]
+
+# Deploy step (only runs if tests succeed)
+[deploy]
+type = "Command"
+command_name = "make deploy"
+description = "Deploy application"
+depends_on = ["test:success"]  # Shorthand for: when = "{{ has_succeeded('test') }}"
+
+# Rollback step (only runs if deploy fails)
+[rollback]
+type = "Command"
+command_name = "make rollback"
+description = "Rollback deployment"
+depends_on = ["deploy:failure"]  # Shorthand for: when = "{{ has_failed('deploy') }}"
+
+# Cleanup success (runs if deploy succeeds)
+[cleanup_success]
+type = "Command"
+command_name = "cleanup.sh --mode=success"
+description = "Clean up after successful deployment"
+depends_on = ["deploy:success"]
+
+# Cleanup failure (runs if deploy fails OR rollback succeeds)
+[cleanup_failure]
+type = "Command"
+command_name = "cleanup.sh --mode=failure"
+description = "Clean up after failed deployment"
+depends_on = ["deploy:failure", "rollback:success"]  # Multiple conditions with AND
+
+# Notification (runs after any cleanup)
+[notify]
+type = "Manual"
+prompt_after = "Deployment process completed. Review logs and continue."
+description = "Final notification"
+depends_on = ["cleanup_success", "cleanup_failure"]
+# This will run if either cleanup_success OR cleanup_failure completes
+# (regular dependencies are OR by default, conditions within depends_on are AND)

--- a/examples/conditional_deployment.playbook.toml
+++ b/examples/conditional_deployment.playbook.toml
@@ -1,0 +1,101 @@
+# Conditional Deployment Workflow Example
+# This example demonstrates conditional branching based on node outcomes
+
+[variables]
+ENVIRONMENT = { required = true, choices = ["dev", "staging", "prod"], description = "Target deployment environment" }
+SKIP_TESTS = { default = false, type = "bool", description = "Skip running tests" }
+ENABLE_ROLLBACK = { default = true, type = "bool", description = "Enable automatic rollback on failure" }
+
+[runbook]
+title = "Conditional Deployment Pipeline"
+description = "Advanced deployment pipeline with conditional branching based on test results and environment"
+version = "1.0.0"
+author = "devops-team"
+created_at = "2025-01-20T12:00:00Z"
+
+# Build the application (always runs)
+[build_application]
+type = "Command"
+command_name = "npm run build"
+description = "Build the application"
+depends_on = []
+
+# Run tests (conditional based on SKIP_TESTS variable)
+[run_tests]
+type = "Command"
+command_name = "npm test"
+description = "Run unit and integration tests"
+depends_on = ["build_application"]
+when = "{{ not SKIP_TESTS and has_succeeded('build_application') }}"
+
+# Security scan (only for production)
+[security_scan]
+type = "Command"
+command_name = "npm audit --audit-level high"
+description = "Run security audit"
+depends_on = ["build_application"]
+when = "{{ ENVIRONMENT == 'prod' and has_succeeded('build_application') }}"
+
+# Deploy to development (only if build succeeded and environment is dev)
+[deploy_development]
+type = "Command"
+command_name = "deploy.sh dev"
+description = "Deploy to development environment"
+depends_on = ["build_application"]
+when = "{{ ENVIRONMENT == 'dev' and has_succeeded('build_application') }}"
+
+# Deploy to staging (only if tests pass and environment is staging)
+[deploy_staging]
+type = "Command"
+command_name = "deploy.sh staging"
+description = "Deploy to staging environment"
+depends_on = ["run_tests"]
+when = "{{ ENVIRONMENT == 'staging' and (SKIP_TESTS or has_succeeded('run_tests')) }}"
+
+# Manual approval for production (only for prod environment)
+[production_approval]
+type = "Manual"
+prompt_after = "Ready to deploy to production? This will affect live users."
+description = "Manual approval for production deployment"
+depends_on = ["run_tests", "security_scan"]
+when = "{{ ENVIRONMENT == 'prod' }}"
+
+# Deploy to production (only after approval and all checks pass)
+[deploy_production]
+type = "Command"
+command_name = "deploy.sh prod"
+description = "Deploy to production environment"
+depends_on = ["production_approval"]
+when = "{{ ENVIRONMENT == 'prod' and has_succeeded('production_approval') and (SKIP_TESTS or has_succeeded('run_tests')) and has_succeeded('security_scan') }}"
+
+# Health check (runs after any deployment)
+[health_check]
+type = "Command"
+command_name = "curl -f https://{{ENVIRONMENT}}.myapp.com/health"
+description = "Verify deployment health"
+depends_on = ["deploy_development", "deploy_staging", "deploy_production"]
+when = "{{ has_succeeded('deploy_development') or has_succeeded('deploy_staging') or has_succeeded('deploy_production') }}"
+
+# Rollback (only if health check fails and rollback is enabled)
+[rollback_deployment]
+type = "Command"
+command_name = "rollback.sh {{ENVIRONMENT}}"
+description = "Rollback failed deployment"
+depends_on = ["health_check"]
+when = "{{ ENABLE_ROLLBACK and has_failed('health_check') }}"
+
+# Notification for successful deployment
+[notify_success]
+type = "Manual"
+prompt_after = "Deployment completed successfully. Continue?"
+description = "Notify team of successful deployment"
+depends_on = ["health_check"]
+when = "{{ has_succeeded('health_check') }}"
+
+# Notification for failed deployment
+[notify_failure]
+type = "Manual"
+prompt_after = "Deployment failed. Incident response may be required. Continue?"
+description = "Notify team of deployment failure"
+depends_on = ["deploy_development", "deploy_staging", "deploy_production", "rollback_deployment"]
+when = "{{ has_failed('deploy_development') or has_failed('deploy_staging') or has_failed('deploy_production') or has_succeeded('rollback_deployment') }}"

--- a/src/playbook/cli/commands/run.py
+++ b/src/playbook/cli/commands/run.py
@@ -211,7 +211,14 @@ def _execute_workflow(
 
     # Execute the workflow
     _execute_nodes(
-        engine, runbook, run_info, nodes_to_run, progress, io_handler, max_retries
+        engine,
+        runbook,
+        run_info,
+        nodes_to_run,
+        progress,
+        io_handler,
+        max_retries,
+        variables,
     )
 
 
@@ -271,6 +278,7 @@ def _execute_nodes(
     progress: Progress,
     io_handler: ConsoleNodeIOHandler,
     max_retries: int = 3,
+    variables: Optional[dict] = None,
 ) -> None:
     """
     Execute the given nodes in the runbook
@@ -311,12 +319,12 @@ def _execute_nodes(
             if existing_execution and existing_execution.status != NodeStatus.OK:
                 # Resume with existing record
                 status, execution = engine.resume_node_execution(
-                    runbook, current_node_id, run_info, existing_execution
+                    runbook, current_node_id, run_info, existing_execution, variables
                 )
             else:
                 # Create new execution record (for fresh nodes)
                 status, execution = engine.execute_node(
-                    runbook, current_node_id, run_info
+                    runbook, current_node_id, run_info, variables
                 )
 
             # Update progress based on result
@@ -408,7 +416,11 @@ def _execute_nodes(
 
                             # Execute single retry attempt creating a new execution record
                             status, execution = engine.execute_node_retry(
-                                runbook, current_node_id, run_info, next_attempt
+                                runbook,
+                                current_node_id,
+                                run_info,
+                                next_attempt,
+                                variables,
                             )
 
                             if status == NodeStatus.OK:

--- a/src/playbook/domain/models.py
+++ b/src/playbook/domain/models.py
@@ -42,6 +42,7 @@ class BaseNode(BaseModel):
     prompt_before: str = ""
     prompt_after: str = "Continue with the next step?"  # "" for no prompt
     skip: bool = False
+    when: str = "true"  # Conditional execution clause, defaults to always execute
 
 
 class ManualNode(BaseNode):

--- a/src/playbook/infrastructure/conditions.py
+++ b/src/playbook/infrastructure/conditions.py
@@ -1,0 +1,194 @@
+# src/playbook/infrastructure/conditions.py
+"""Conditional execution support for workflow nodes."""
+
+import re
+from typing import Dict, List, Any, Optional, Tuple
+from jinja2 import Environment, Template, BaseLoader
+from ..domain.models import NodeExecution, NodeStatus
+
+
+class ConditionalDependency:
+    """Represents a conditional dependency like 'node_id:success' or 'node_id:failure'."""
+
+    def __init__(self, node_id: str, condition: Optional[str] = None):
+        self.node_id = node_id
+        self.condition = condition  # None, 'success', 'failure'
+
+    @classmethod
+    def parse(cls, dependency: str) -> "ConditionalDependency":
+        """Parse a dependency string into node_id and optional condition.
+
+        Examples:
+            'deploy' -> ConditionalDependency('deploy', None)
+            'deploy:success' -> ConditionalDependency('deploy', 'success')
+            'deploy:failure' -> ConditionalDependency('deploy', 'failure')
+        """
+        if ":" in dependency:
+            node_id, condition = dependency.split(":", 1)
+            if condition not in ["success", "failure"]:
+                raise ValueError(
+                    f"Invalid condition '{condition}'. Must be 'success' or 'failure'"
+                )
+            return cls(node_id, condition)
+        else:
+            return cls(dependency, None)
+
+    def to_when_clause(self) -> str:
+        """Convert conditional dependency to equivalent 'when' clause."""
+        if self.condition is None:
+            return "true"  # Unconditional dependency
+        elif self.condition == "success":
+            return f'{{{{ has_succeeded("{self.node_id}") }}}}'
+        elif self.condition == "failure":
+            return f'{{{{ has_failed("{self.node_id}") }}}}'
+        else:
+            raise ValueError(f"Unknown condition: {self.condition}")
+
+
+class ConditionContext:
+    """Provides context functions for evaluating 'when' conditions."""
+
+    def __init__(self, executions: Dict[str, NodeExecution]):
+        self.executions = executions
+
+    def previous_node(self, node_id: str) -> Dict[str, Any]:
+        """Get execution details for a previous node."""
+        execution = self.executions.get(node_id)
+        if execution is None:
+            return {
+                "exit_code": None,
+                "status": None,
+                "output": None,
+                "stdout": None,
+                "stderr": None,
+                "exists": False,
+            }
+
+        return {
+            "exit_code": execution.exit_code,
+            "status": execution.status.value if execution.status else None,
+            "output": execution.stdout or execution.result_text,
+            "stdout": execution.stdout,
+            "stderr": execution.stderr,
+            "result_text": execution.result_text,
+            "exists": True,
+        }
+
+    def has_succeeded(self, node_id: str) -> bool:
+        """Check if a node has succeeded."""
+        execution = self.executions.get(node_id)
+        return execution is not None and execution.status == NodeStatus.OK
+
+    def has_failed(self, node_id: str) -> bool:
+        """Check if a node has failed."""
+        execution = self.executions.get(node_id)
+        return execution is not None and execution.status == NodeStatus.NOK
+
+    def has_run(self, node_id: str) -> bool:
+        """Check if a node has been executed (regardless of outcome)."""
+        return node_id in self.executions
+
+    def is_skipped(self, node_id: str) -> bool:
+        """Check if a node was skipped."""
+        execution = self.executions.get(node_id)
+        return execution is not None and execution.status == NodeStatus.SKIPPED
+
+
+class ConditionEvaluator:
+    """Evaluates 'when' conditions using Jinja2 templates."""
+
+    def __init__(self):
+        self.env = Environment(loader=BaseLoader())
+
+    def evaluate(
+        self, condition: str, variables: Dict[str, Any], context: ConditionContext
+    ) -> bool:
+        """Evaluate a condition string and return boolean result.
+
+        Args:
+            condition: Jinja2 template string to evaluate
+            variables: Workflow variables available in the condition
+            context: Execution context with helper functions
+
+        Returns:
+            Boolean result of condition evaluation
+        """
+        try:
+            # Create template from condition
+            template = self.env.from_string(condition)
+
+            # Prepare context with variables and helper functions
+            template_context = {
+                **variables,
+                "previous_node": context.previous_node,
+                "has_succeeded": context.has_succeeded,
+                "has_failed": context.has_failed,
+                "has_run": context.has_run,
+                "is_skipped": context.is_skipped,
+            }
+
+            # Render template and convert to boolean
+            result = template.render(template_context)
+
+            # Handle different result types
+            if isinstance(result, bool):
+                return result
+            elif isinstance(result, str):
+                # Handle string boolean representations
+                result_lower = result.lower().strip()
+                if result_lower in ("true", "1", "yes", "on"):
+                    return True
+                elif result_lower in ("false", "0", "no", "off", ""):
+                    return False
+                else:
+                    # Try to evaluate as Python expression for numbers/expressions
+                    try:
+                        return bool(eval(result_lower))
+                    except:
+                        # If all else fails, non-empty string is truthy
+                        return bool(result_lower)
+            else:
+                # For numbers, None, etc.
+                return bool(result)
+
+        except Exception as e:
+            raise ValueError(f"Failed to evaluate condition '{condition}': {e}")
+
+
+def parse_dependencies(dependencies: List[str]) -> Tuple[List[str], str]:
+    """Parse dependency list and return (node_ids, combined_when_clause).
+
+    Converts conditional dependencies to equivalent 'when' conditions.
+
+    Args:
+        dependencies: List of dependency strings (may include conditions)
+
+    Returns:
+        Tuple of (clean_node_ids, when_clause)
+
+    Examples:
+        ['deploy'] -> (['deploy'], 'true')
+        ['deploy:success'] -> (['deploy'], '{{ has_succeeded("deploy") }}')
+        ['build', 'test:success'] -> (['build', 'test'], '{{ has_succeeded("test") }}')
+    """
+    node_ids = []
+    conditions = []
+
+    for dep in dependencies:
+        conditional_dep = ConditionalDependency.parse(dep)
+        node_ids.append(conditional_dep.node_id)
+
+        if conditional_dep.condition:
+            conditions.append(conditional_dep.to_when_clause())
+
+    # Combine multiple conditions with AND
+    if not conditions:
+        when_clause = "true"
+    elif len(conditions) == 1:
+        when_clause = conditions[0]
+    else:
+        # Join multiple conditions with 'and'
+        condition_parts = [c.strip("{}").strip() for c in conditions]
+        when_clause = "{{ " + " and ".join(condition_parts) + " }}"
+
+    return node_ids, when_clause

--- a/tests/test_infrastructure/test_conditional_parsing.py
+++ b/tests/test_infrastructure/test_conditional_parsing.py
@@ -1,0 +1,359 @@
+# tests/test_infrastructure/test_conditional_parsing.py
+"""Tests for conditional dependency parsing in TOML files."""
+
+import pytest
+import tempfile
+import os
+from datetime import datetime
+
+from src.playbook.infrastructure.parser import RunbookParser
+from src.playbook.infrastructure.variables import VariableManager
+
+
+class TestConditionalParsing:
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.variable_manager = VariableManager(interactive=False)
+        self.parser = RunbookParser(self.variable_manager)
+
+    def create_temp_playbook(self, content: str) -> str:
+        """Create a temporary playbook file with given content."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".playbook.toml", delete=False
+        ) as f:
+            f.write(content)
+            return f.name
+
+    def teardown_method(self):
+        """Clean up temporary files."""
+        pass
+
+    def test_parse_simple_when_clause(self):
+        """Test parsing runbook with simple when clause."""
+        toml_content = """
+[runbook]
+title = "Conditional Test"
+description = "Test conditional execution"
+version = "1.0.0"
+author = "test"
+created_at = "2025-01-01T12:00:00Z"
+
+[build]
+type = "Command"
+command_name = "make build"
+depends_on = []
+
+[deploy]
+type = "Command"
+command_name = "make deploy"
+depends_on = ["build"]
+when = "{{ ENVIRONMENT == 'prod' }}"
+"""
+
+        file_path = self.create_temp_playbook(toml_content)
+        try:
+            runbook = self.parser.parse(file_path, {"ENVIRONMENT": "prod"})
+
+            assert len(runbook.nodes) == 2
+            assert "build" in runbook.nodes
+            assert "deploy" in runbook.nodes
+
+            deploy_node = runbook.nodes["deploy"]
+            assert deploy_node.when == "{{ ENVIRONMENT == 'prod' }}"
+            assert deploy_node.depends_on == ["build"]
+
+        finally:
+            os.unlink(file_path)
+
+    def test_parse_conditional_dependencies_success(self):
+        """Test parsing conditional dependencies with success condition."""
+        toml_content = """
+[runbook]
+title = "Conditional Dependencies Test"
+description = "Test conditional dependencies"
+version = "1.0.0"
+author = "test"
+created_at = "2025-01-01T12:00:00Z"
+
+[build]
+type = "Command"
+command_name = "make build"
+depends_on = []
+
+[test]
+type = "Command"
+command_name = "make test"
+depends_on = ["build"]
+
+[deploy]
+type = "Command"
+command_name = "make deploy"
+depends_on = ["test:success"]
+"""
+
+        file_path = self.create_temp_playbook(toml_content)
+        try:
+            runbook = self.parser.parse(file_path)
+
+            deploy_node = runbook.nodes["deploy"]
+            assert deploy_node.depends_on == ["test"]
+            assert 'has_succeeded("test")' in deploy_node.when
+
+        finally:
+            os.unlink(file_path)
+
+    def test_parse_conditional_dependencies_failure(self):
+        """Test parsing conditional dependencies with failure condition."""
+        toml_content = """
+[runbook]
+title = "Conditional Dependencies Test"
+description = "Test conditional dependencies"
+version = "1.0.0"
+author = "test"
+created_at = "2025-01-01T12:00:00Z"
+
+[deploy]
+type = "Command"
+command_name = "make deploy"
+depends_on = []
+
+[rollback]
+type = "Command"
+command_name = "make rollback"
+depends_on = ["deploy:failure"]
+"""
+
+        file_path = self.create_temp_playbook(toml_content)
+        try:
+            runbook = self.parser.parse(file_path)
+
+            rollback_node = runbook.nodes["rollback"]
+            assert rollback_node.depends_on == ["deploy"]
+            assert 'has_failed("deploy")' in rollback_node.when
+
+        finally:
+            os.unlink(file_path)
+
+    def test_parse_mixed_conditional_dependencies(self):
+        """Test parsing mixed conditional and regular dependencies."""
+        toml_content = """
+[runbook]
+title = "Mixed Dependencies Test"
+description = "Test mixed dependencies"
+version = "1.0.0"
+author = "test"
+created_at = "2025-01-01T12:00:00Z"
+
+[build]
+type = "Command"
+command_name = "make build"
+depends_on = []
+
+[test]
+type = "Command"
+command_name = "make test"
+depends_on = []
+
+[deploy]
+type = "Command"
+command_name = "make deploy"
+depends_on = ["build", "test:success"]
+"""
+
+        file_path = self.create_temp_playbook(toml_content)
+        try:
+            runbook = self.parser.parse(file_path)
+
+            deploy_node = runbook.nodes["deploy"]
+            assert deploy_node.depends_on == ["build", "test"]
+            assert 'has_succeeded("test")' in deploy_node.when
+
+        finally:
+            os.unlink(file_path)
+
+    def test_parse_multiple_conditional_dependencies(self):
+        """Test parsing multiple conditional dependencies."""
+        toml_content = """
+[runbook]
+title = "Multiple Conditional Dependencies"
+description = "Test multiple conditional dependencies"
+version = "1.0.0"
+author = "test"
+created_at = "2025-01-01T12:00:00Z"
+
+[build]
+type = "Command"
+command_name = "make build"
+depends_on = []
+
+[test]
+type = "Command"
+command_name = "make test"
+depends_on = []
+
+[security_scan]
+type = "Command"
+command_name = "security scan"
+depends_on = []
+
+[deploy]
+type = "Command"
+command_name = "make deploy"
+depends_on = ["build:success", "test:success", "security_scan:success"]
+"""
+
+        file_path = self.create_temp_playbook(toml_content)
+        try:
+            runbook = self.parser.parse(file_path)
+
+            deploy_node = runbook.nodes["deploy"]
+            assert deploy_node.depends_on == ["build", "test", "security_scan"]
+            # Check that all success conditions are combined with AND
+            assert 'has_succeeded("build")' in deploy_node.when
+            assert 'has_succeeded("test")' in deploy_node.when
+            assert 'has_succeeded("security_scan")' in deploy_node.when
+            assert "and" in deploy_node.when
+
+        finally:
+            os.unlink(file_path)
+
+    def test_parse_when_clause_with_conditional_dependencies(self):
+        """Test combining explicit when clause with conditional dependencies."""
+        toml_content = """
+[runbook]
+title = "Combined Conditions Test"
+description = "Test combined conditions"
+version = "1.0.0"
+author = "test"
+created_at = "2025-01-01T12:00:00Z"
+
+[build]
+type = "Command"
+command_name = "make build"
+depends_on = []
+
+[deploy]
+type = "Command"
+command_name = "make deploy"
+depends_on = ["build:success"]
+when = "{{ ENVIRONMENT == 'prod' }}"
+"""
+
+        file_path = self.create_temp_playbook(toml_content)
+        try:
+            runbook = self.parser.parse(file_path, {"ENVIRONMENT": "prod"})
+
+            deploy_node = runbook.nodes["deploy"]
+            assert deploy_node.depends_on == ["build"]
+            # Check that both conditions are combined
+            assert "ENVIRONMENT == 'prod'" in deploy_node.when
+            assert 'has_succeeded("build")' in deploy_node.when
+            assert "and" in deploy_node.when
+
+        finally:
+            os.unlink(file_path)
+
+    def test_parse_invalid_conditional_dependency(self):
+        """Test parsing invalid conditional dependency."""
+        toml_content = """
+[runbook]
+title = "Invalid Conditional Test"
+description = "Test invalid conditional dependency"
+version = "1.0.0"
+author = "test"
+created_at = "2025-01-01T12:00:00Z"
+
+[deploy]
+type = "Command"
+command_name = "make deploy"
+depends_on = ["build:invalid"]
+"""
+
+        file_path = self.create_temp_playbook(toml_content)
+        try:
+            with pytest.raises(ValueError, match="Invalid condition 'invalid'"):
+                self.parser.parse(file_path)
+
+        finally:
+            os.unlink(file_path)
+
+    def test_parse_runbook_with_variable_in_when_clause(self):
+        """Test parsing runbook with variables in when clause."""
+        toml_content = """
+[variables]
+ENVIRONMENT = { default = "dev", choices = ["dev", "staging", "prod"] }
+ENABLE_DEPLOY = { default = true, type = "bool" }
+
+[runbook]
+title = "Variable Conditional Test"
+description = "Test variables in conditions"
+version = "1.0.0"
+author = "test"
+created_at = "2025-01-01T12:00:00Z"
+
+[build]
+type = "Command"
+command_name = "make build"
+depends_on = []
+
+[deploy]
+type = "Command"
+command_name = "make deploy"
+depends_on = ["build"]
+when = "{{ ENVIRONMENT == 'prod' and ENABLE_DEPLOY }}"
+"""
+
+        file_path = self.create_temp_playbook(toml_content)
+        try:
+            # Test with variables that should enable deployment
+            runbook = self.parser.parse(
+                file_path, {"ENVIRONMENT": "prod", "ENABLE_DEPLOY": True}
+            )
+
+            deploy_node = runbook.nodes["deploy"]
+            assert "ENVIRONMENT == 'prod'" in deploy_node.when
+            assert "ENABLE_DEPLOY" in deploy_node.when
+
+        finally:
+            os.unlink(file_path)
+
+    def test_backward_compatibility_simple_dependencies(self):
+        """Test that simple dependencies still work without conditions."""
+        toml_content = """
+[runbook]
+title = "Backward Compatibility Test"
+description = "Test backward compatibility"
+version = "1.0.0"
+author = "test"
+created_at = "2025-01-01T12:00:00Z"
+
+[build]
+type = "Command"
+command_name = "make build"
+depends_on = []
+
+[test]
+type = "Command"
+command_name = "make test"
+depends_on = ["build"]
+
+[deploy]
+type = "Command"
+command_name = "make deploy"
+depends_on = ["build", "test"]
+"""
+
+        file_path = self.create_temp_playbook(toml_content)
+        try:
+            runbook = self.parser.parse(file_path)
+
+            # All nodes should have default when="true"
+            for node_id, node in runbook.nodes.items():
+                assert node.when == "true"
+
+            # Dependencies should be preserved
+            assert runbook.nodes["test"].depends_on == ["build"]
+            assert runbook.nodes["deploy"].depends_on == ["build", "test"]
+
+        finally:
+            os.unlink(file_path)

--- a/tests/test_infrastructure/test_conditions.py
+++ b/tests/test_infrastructure/test_conditions.py
@@ -1,0 +1,260 @@
+# tests/test_infrastructure/test_conditions.py
+"""Tests for conditional execution support."""
+
+import pytest
+from datetime import datetime
+from typing import Dict
+
+from src.playbook.infrastructure.conditions import (
+    ConditionalDependency,
+    ConditionContext,
+    ConditionEvaluator,
+    parse_dependencies,
+)
+from src.playbook.domain.models import NodeExecution, NodeStatus
+
+
+class TestConditionalDependency:
+    def test_parse_simple_dependency(self):
+        """Test parsing simple dependency without condition."""
+        dep = ConditionalDependency.parse("deploy")
+        assert dep.node_id == "deploy"
+        assert dep.condition is None
+
+    def test_parse_success_condition(self):
+        """Test parsing success condition dependency."""
+        dep = ConditionalDependency.parse("deploy:success")
+        assert dep.node_id == "deploy"
+        assert dep.condition == "success"
+
+    def test_parse_failure_condition(self):
+        """Test parsing failure condition dependency."""
+        dep = ConditionalDependency.parse("deploy:failure")
+        assert dep.node_id == "deploy"
+        assert dep.condition == "failure"
+
+    def test_parse_invalid_condition(self):
+        """Test parsing invalid condition raises error."""
+        with pytest.raises(ValueError, match="Invalid condition 'unknown'"):
+            ConditionalDependency.parse("deploy:unknown")
+
+    def test_to_when_clause_simple(self):
+        """Test converting simple dependency to when clause."""
+        dep = ConditionalDependency("deploy", None)
+        assert dep.to_when_clause() == "true"
+
+    def test_to_when_clause_success(self):
+        """Test converting success condition to when clause."""
+        dep = ConditionalDependency("deploy", "success")
+        assert dep.to_when_clause() == '{{ has_succeeded("deploy") }}'
+
+    def test_to_when_clause_failure(self):
+        """Test converting failure condition to when clause."""
+        dep = ConditionalDependency("deploy", "failure")
+        assert dep.to_when_clause() == '{{ has_failed("deploy") }}'
+
+
+class TestConditionContext:
+    def test_previous_node_exists(self):
+        """Test accessing previous node that exists."""
+        execution = NodeExecution(
+            workflow_name="test",
+            run_id=1,
+            node_id="deploy",
+            attempt=1,
+            start_time=datetime.now(),
+            status=NodeStatus.OK,
+            exit_code=0,
+            stdout="Success",
+        )
+
+        context = ConditionContext({"deploy": execution})
+        result = context.previous_node("deploy")
+
+        assert result["exists"] is True
+        assert result["exit_code"] == 0
+        assert result["status"] == "ok"
+        assert result["stdout"] == "Success"
+
+    def test_previous_node_missing(self):
+        """Test accessing previous node that doesn't exist."""
+        context = ConditionContext({})
+        result = context.previous_node("deploy")
+
+        assert result["exists"] is False
+        assert result["exit_code"] is None
+        assert result["status"] is None
+
+    def test_has_succeeded(self):
+        """Test has_succeeded helper function."""
+        execution = NodeExecution(
+            workflow_name="test",
+            run_id=1,
+            node_id="deploy",
+            attempt=1,
+            start_time=datetime.now(),
+            status=NodeStatus.OK,
+        )
+
+        context = ConditionContext({"deploy": execution})
+        assert context.has_succeeded("deploy") is True
+        assert context.has_succeeded("missing") is False
+
+    def test_has_failed(self):
+        """Test has_failed helper function."""
+        execution = NodeExecution(
+            workflow_name="test",
+            run_id=1,
+            node_id="deploy",
+            attempt=1,
+            start_time=datetime.now(),
+            status=NodeStatus.NOK,
+        )
+
+        context = ConditionContext({"deploy": execution})
+        assert context.has_failed("deploy") is True
+        assert context.has_failed("missing") is False
+
+    def test_has_run(self):
+        """Test has_run helper function."""
+        execution = NodeExecution(
+            workflow_name="test",
+            run_id=1,
+            node_id="deploy",
+            attempt=1,
+            start_time=datetime.now(),
+            status=NodeStatus.OK,
+        )
+
+        context = ConditionContext({"deploy": execution})
+        assert context.has_run("deploy") is True
+        assert context.has_run("missing") is False
+
+    def test_is_skipped(self):
+        """Test is_skipped helper function."""
+        execution = NodeExecution(
+            workflow_name="test",
+            run_id=1,
+            node_id="deploy",
+            attempt=1,
+            start_time=datetime.now(),
+            status=NodeStatus.SKIPPED,
+        )
+
+        context = ConditionContext({"deploy": execution})
+        assert context.is_skipped("deploy") is True
+        assert context.is_skipped("missing") is False
+
+
+class TestConditionEvaluator:
+    def test_evaluate_true_condition(self):
+        """Test evaluating true condition."""
+        evaluator = ConditionEvaluator()
+        context = ConditionContext({})
+
+        result = evaluator.evaluate("true", {}, context)
+        assert result is True
+
+    def test_evaluate_false_condition(self):
+        """Test evaluating false condition."""
+        evaluator = ConditionEvaluator()
+        context = ConditionContext({})
+
+        result = evaluator.evaluate("false", {}, context)
+        assert result is False
+
+    def test_evaluate_variable_condition(self):
+        """Test evaluating condition with variables."""
+        evaluator = ConditionEvaluator()
+        context = ConditionContext({})
+        variables = {"ENVIRONMENT": "prod"}
+
+        result = evaluator.evaluate("{{ ENVIRONMENT == 'prod' }}", variables, context)
+        assert result is True
+
+        result = evaluator.evaluate("{{ ENVIRONMENT == 'dev' }}", variables, context)
+        assert result is False
+
+    def test_evaluate_helper_function_condition(self):
+        """Test evaluating condition with helper functions."""
+        execution = NodeExecution(
+            workflow_name="test",
+            run_id=1,
+            node_id="build",
+            attempt=1,
+            start_time=datetime.now(),
+            status=NodeStatus.OK,
+        )
+
+        evaluator = ConditionEvaluator()
+        context = ConditionContext({"build": execution})
+
+        result = evaluator.evaluate("{{ has_succeeded('build') }}", {}, context)
+        assert result is True
+
+        result = evaluator.evaluate("{{ has_failed('build') }}", {}, context)
+        assert result is False
+
+    def test_evaluate_complex_condition(self):
+        """Test evaluating complex condition with multiple parts."""
+        execution = NodeExecution(
+            workflow_name="test",
+            run_id=1,
+            node_id="build",
+            attempt=1,
+            start_time=datetime.now(),
+            status=NodeStatus.OK,
+            exit_code=0,
+        )
+
+        evaluator = ConditionEvaluator()
+        context = ConditionContext({"build": execution})
+        variables = {"ENVIRONMENT": "prod"}
+
+        condition = "{{ ENVIRONMENT == 'prod' and has_succeeded('build') and previous_node('build').exit_code == 0 }}"
+        result = evaluator.evaluate(condition, variables, context)
+        assert result is True
+
+    def test_evaluate_invalid_condition(self):
+        """Test evaluating invalid condition raises error."""
+        evaluator = ConditionEvaluator()
+        context = ConditionContext({})
+
+        with pytest.raises(ValueError, match="Failed to evaluate condition"):
+            evaluator.evaluate("{{ invalid_syntax", {}, context)
+
+
+class TestParseDependencies:
+    def test_parse_simple_dependencies(self):
+        """Test parsing simple dependencies without conditions."""
+        dependencies = ["build", "test"]
+        node_ids, when_clause = parse_dependencies(dependencies)
+
+        assert node_ids == ["build", "test"]
+        assert when_clause == "true"
+
+    def test_parse_conditional_dependencies(self):
+        """Test parsing conditional dependencies."""
+        dependencies = ["build:success", "test:failure"]
+        node_ids, when_clause = parse_dependencies(dependencies)
+
+        assert node_ids == ["build", "test"]
+        assert 'has_succeeded("build")' in when_clause
+        assert 'has_failed("test")' in when_clause
+        assert "and" in when_clause
+
+    def test_parse_mixed_dependencies(self):
+        """Test parsing mixed simple and conditional dependencies."""
+        dependencies = ["build", "test:success"]
+        node_ids, when_clause = parse_dependencies(dependencies)
+
+        assert node_ids == ["build", "test"]
+        assert when_clause == '{{ has_succeeded("test") }}'
+
+    def test_parse_single_conditional_dependency(self):
+        """Test parsing single conditional dependency."""
+        dependencies = ["deploy:success"]
+        node_ids, when_clause = parse_dependencies(dependencies)
+
+        assert node_ids == ["deploy"]
+        assert when_clause == '{{ has_succeeded("deploy") }}'

--- a/tests/test_service/test_conditional_execution.py
+++ b/tests/test_service/test_conditional_execution.py
@@ -1,0 +1,349 @@
+# tests/test_service/test_conditional_execution.py
+"""Integration tests for conditional node execution."""
+
+import pytest
+from datetime import datetime
+from unittest.mock import Mock, MagicMock
+
+from src.playbook.service.engine import RunbookEngine
+from src.playbook.domain.models import (
+    Runbook,
+    RunInfo,
+    NodeExecution,
+    ManualNode,
+    CommandNode,
+    NodeType,
+    NodeStatus,
+    RunStatus,
+    TriggerType,
+)
+
+
+class TestConditionalExecution:
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.mock_clock = Mock()
+        self.mock_clock.now.return_value = datetime(2025, 1, 1, 12, 0, 0)
+
+        self.mock_process_runner = Mock()
+        self.mock_run_repo = Mock()
+        self.mock_node_repo = Mock()
+        self.mock_io_handler = Mock()
+
+        self.engine = RunbookEngine(
+            clock=self.mock_clock,
+            process_runner=self.mock_process_runner,
+            run_repo=self.mock_run_repo,
+            node_repo=self.mock_node_repo,
+            io_handler=self.mock_io_handler,
+        )
+
+    def create_test_runbook_with_conditions(self):
+        """Create a test runbook with conditional nodes."""
+        nodes = {
+            "build": ManualNode(
+                id="build",
+                type=NodeType.MANUAL,
+                name="Build Application",
+                depends_on=[],
+                when="true",  # Always execute
+            ),
+            "test": CommandNode(
+                id="test",
+                type=NodeType.COMMAND,
+                name="Run Tests",
+                command_name="npm test",
+                depends_on=["build"],
+                when="{{ has_succeeded('build') }}",  # Only if build succeeded
+            ),
+            "deploy_staging": CommandNode(
+                id="deploy_staging",
+                type=NodeType.COMMAND,
+                name="Deploy to Staging",
+                command_name="deploy staging",
+                depends_on=["test"],
+                when="{{ has_succeeded('test') }}",  # Only if tests passed
+            ),
+            "deploy_production": CommandNode(
+                id="deploy_production",
+                type=NodeType.COMMAND,
+                name="Deploy to Production",
+                command_name="deploy production",
+                depends_on=["deploy_staging"],
+                when="{{ ENVIRONMENT == 'prod' and has_succeeded('deploy_staging') }}",
+            ),
+            "rollback": CommandNode(
+                id="rollback",
+                type=NodeType.COMMAND,
+                name="Rollback Deployment",
+                command_name="rollback",
+                depends_on=["deploy_production"],
+                when="{{ has_failed('deploy_production') }}",  # Only if production deploy failed
+            ),
+        }
+
+        return Runbook(
+            title="Conditional Deployment",
+            description="Deployment with conditional branching",
+            version="1.0.0",
+            author="test",
+            created_at=datetime.now(),
+            nodes=nodes,
+        )
+
+    def test_should_execute_node_with_true_condition(self):
+        """Test that node executes when condition is true."""
+        runbook = self.create_test_runbook_with_conditions()
+        run_info = RunInfo(
+            workflow_name="test",
+            run_id=1,
+            start_time=datetime.now(),
+            status=RunStatus.RUNNING,
+            trigger=TriggerType.RUN,
+        )
+
+        # Mock existing executions (build succeeded)
+        build_execution = NodeExecution(
+            workflow_name="test",
+            run_id=1,
+            node_id="build",
+            attempt=1,
+            start_time=datetime.now(),
+            status=NodeStatus.OK,
+        )
+        self.mock_node_repo.get_executions.return_value = [build_execution]
+
+        # Test that 'test' node should execute (build succeeded)
+        test_node = runbook.nodes["test"]
+        should_execute = self.engine._should_execute_node(
+            test_node, runbook, run_info, {}
+        )
+        assert should_execute is True
+
+    def test_should_execute_node_with_false_condition(self):
+        """Test that node doesn't execute when condition is false."""
+        runbook = self.create_test_runbook_with_conditions()
+        run_info = RunInfo(
+            workflow_name="test",
+            run_id=1,
+            start_time=datetime.now(),
+            status=RunStatus.RUNNING,
+            trigger=TriggerType.RUN,
+        )
+
+        # Mock existing executions (build failed)
+        build_execution = NodeExecution(
+            workflow_name="test",
+            run_id=1,
+            node_id="build",
+            attempt=1,
+            start_time=datetime.now(),
+            status=NodeStatus.NOK,
+        )
+        self.mock_node_repo.get_executions.return_value = [build_execution]
+
+        # Test that 'test' node should not execute (build failed)
+        test_node = runbook.nodes["test"]
+        should_execute = self.engine._should_execute_node(
+            test_node, runbook, run_info, {}
+        )
+        assert should_execute is False
+
+    def test_should_execute_node_with_variable_condition(self):
+        """Test condition evaluation with variables."""
+        runbook = self.create_test_runbook_with_conditions()
+        run_info = RunInfo(
+            workflow_name="test",
+            run_id=1,
+            start_time=datetime.now(),
+            status=RunStatus.RUNNING,
+            trigger=TriggerType.RUN,
+        )
+
+        # Mock existing executions (staging deploy succeeded)
+        staging_execution = NodeExecution(
+            workflow_name="test",
+            run_id=1,
+            node_id="deploy_staging",
+            attempt=1,
+            start_time=datetime.now(),
+            status=NodeStatus.OK,
+        )
+        self.mock_node_repo.get_executions.return_value = [staging_execution]
+
+        # Test with ENVIRONMENT = 'prod'
+        prod_node = runbook.nodes["deploy_production"]
+        should_execute = self.engine._should_execute_node(
+            prod_node, runbook, run_info, {"ENVIRONMENT": "prod"}
+        )
+        assert should_execute is True
+
+        # Test with ENVIRONMENT = 'dev'
+        should_execute = self.engine._should_execute_node(
+            prod_node, runbook, run_info, {"ENVIRONMENT": "dev"}
+        )
+        assert should_execute is False
+
+    def test_execute_node_skipped_by_condition(self):
+        """Test that node is skipped when condition is false."""
+        runbook = self.create_test_runbook_with_conditions()
+        run_info = RunInfo(
+            workflow_name="test",
+            run_id=1,
+            start_time=datetime.now(),
+            status=RunStatus.RUNNING,
+            trigger=TriggerType.RUN,
+        )
+
+        # Mock existing executions (build failed)
+        build_execution = NodeExecution(
+            workflow_name="test",
+            run_id=1,
+            node_id="build",
+            attempt=1,
+            start_time=datetime.now(),
+            status=NodeStatus.NOK,
+        )
+        self.mock_node_repo.get_executions.return_value = [build_execution]
+
+        # Execute test node (should be skipped)
+        status, execution = self.engine.execute_node(runbook, "test", run_info, {})
+
+        assert status == NodeStatus.SKIPPED
+        assert "condition" in execution.result_text.lower()
+        self.mock_node_repo.create_execution.assert_called_once()
+
+    def test_execute_node_condition_evaluates_true(self):
+        """Test that node executes when condition evaluates to true."""
+        runbook = self.create_test_runbook_with_conditions()
+        run_info = RunInfo(
+            workflow_name="test",
+            run_id=1,
+            start_time=datetime.now(),
+            status=RunStatus.RUNNING,
+            trigger=TriggerType.RUN,
+        )
+
+        # Mock existing executions (build succeeded)
+        build_execution = NodeExecution(
+            workflow_name="test",
+            run_id=1,
+            node_id="build",
+            attempt=1,
+            start_time=datetime.now(),
+            status=NodeStatus.OK,
+        )
+        self.mock_node_repo.get_executions.return_value = [build_execution]
+
+        # Mock successful command execution
+        self.mock_process_runner.run_command.return_value = (0, "Tests passed", "")
+
+        # Execute test node (should run because build succeeded)
+        status, execution = self.engine.execute_node(runbook, "test", run_info, {})
+
+        assert status == NodeStatus.OK
+        self.mock_process_runner.run_command.assert_called_once_with(
+            "npm test", 300, False
+        )
+
+    def test_validate_runbook_with_invalid_condition(self):
+        """Test validation fails with invalid when condition."""
+        nodes = {
+            "test": CommandNode(
+                id="test",
+                type=NodeType.COMMAND,
+                name="Test",
+                command_name="test",
+                depends_on=[],
+                when="{{ invalid_syntax",  # Invalid Jinja2 syntax
+            )
+        }
+
+        runbook = Runbook(
+            title="Invalid Condition Test",
+            description="Test",
+            version="1.0.0",
+            author="test",
+            created_at=datetime.now(),
+            nodes=nodes,
+        )
+
+        errors = self.engine.validate(runbook)
+        assert len(errors) > 0
+        assert any("Invalid 'when' condition" in error for error in errors)
+
+    def test_condition_evaluation_error_defaults_to_execute(self):
+        """Test that condition evaluation errors default to executing node."""
+        runbook = self.create_test_runbook_with_conditions()
+        run_info = RunInfo(
+            workflow_name="test",
+            run_id=1,
+            start_time=datetime.now(),
+            status=RunStatus.RUNNING,
+            trigger=TriggerType.RUN,
+        )
+
+        # Mock node_repo.get_executions to raise exception
+        self.mock_node_repo.get_executions.side_effect = Exception("Database error")
+
+        # Test should default to execute (fail-open)
+        test_node = runbook.nodes["test"]
+        should_execute = self.engine._should_execute_node(
+            test_node, runbook, run_info, {}
+        )
+        assert should_execute is True
+
+    def test_complex_conditional_workflow(self):
+        """Test a complex workflow with multiple conditional branches."""
+        runbook = self.create_test_runbook_with_conditions()
+        run_info = RunInfo(
+            workflow_name="test",
+            run_id=1,
+            start_time=datetime.now(),
+            status=RunStatus.RUNNING,
+            trigger=TriggerType.RUN,
+        )
+
+        # Simulate workflow execution: build succeeds, tests succeed, staging fails
+        executions = [
+            NodeExecution(
+                workflow_name="test",
+                run_id=1,
+                node_id="build",
+                attempt=1,
+                start_time=datetime.now(),
+                status=NodeStatus.OK,
+            ),
+            NodeExecution(
+                workflow_name="test",
+                run_id=1,
+                node_id="test",
+                attempt=1,
+                start_time=datetime.now(),
+                status=NodeStatus.OK,
+            ),
+            NodeExecution(
+                workflow_name="test",
+                run_id=1,
+                node_id="deploy_staging",
+                attempt=1,
+                start_time=datetime.now(),
+                status=NodeStatus.NOK,
+            ),
+        ]
+
+        self.mock_node_repo.get_executions.return_value = executions
+
+        # Test that production deploy should not execute (staging failed)
+        prod_node = runbook.nodes["deploy_production"]
+        should_execute = self.engine._should_execute_node(
+            prod_node, runbook, run_info, {"ENVIRONMENT": "prod"}
+        )
+        assert should_execute is False
+
+        # Test that rollback should not execute (production deploy didn't run)
+        rollback_node = runbook.nodes["rollback"]
+        should_execute = self.engine._should_execute_node(
+            rollback_node, runbook, run_info, {}
+        )
+        assert should_execute is False


### PR DESCRIPTION
## Summary

Implements conditional branching functionality for workflow nodes, enabling dynamic execution paths based on node outcomes and variables.

### Key Features

- **Conditional Execution**: Optional `when` field on all nodes with Jinja2 template support
- **Conditional Dependencies**: Shorthand syntax for common patterns (`node_id:success`, `node_id:failure`)
- **Helper Functions**: Built-in functions for condition evaluation (`has_succeeded()`, `has_failed()`, `previous_node()`)
- **Variable Integration**: Full access to workflow variables within conditions
- **Backward Compatibility**: All existing workflows continue to work unchanged

### Implementation Details

- Added `when` field to `BaseNode` with default value "true"
- Created comprehensive condition evaluation system with Jinja2 templating
- Updated parser to handle conditional syntax while preserving runtime evaluation
- Modified engine execution logic to check conditions before node execution
- Enhanced validation to verify condition syntax

### Example Usage

#### Simple Condition
```toml
[deploy]
type = "Command" 
command_name = "deploy.sh prod"
when = "{{ ENVIRONMENT == 'prod' }}"
```

#### Conditional Dependencies
```toml
[rollback]
type = "Command"
command_name = "rollback.sh"
depends_on = ["deploy:failure"]  # Only if deploy fails
```

#### Complex Conditions
```toml
[security_scan]
type = "Command"
command_name = "security-scan.sh"
when = "{{ ENVIRONMENT == 'prod' and has_succeeded('build') and not SKIP_SECURITY }}"
```

### Breaking Changes

None. All existing workflows remain fully compatible.