### PR TITLE
Add simplified dependency syntax for linear workflows

### DIFF
--- a/.idea/copilot.data.migration.ask.xml
+++ b/.idea/copilot.data.migration.ask.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AskMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/.idea/copilot.data.migration.ask2agent.xml
+++ b/.idea/copilot.data.migration.ask2agent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Ask2AgentMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,6 +6,16 @@
   <component name="ChangeListManager">
     <list default="true" id="5a384825-87f7-4752-bb95-dcf8d7a51e56" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/README.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/playbook/domain/models.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/playbook/domain/models.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/playbook/infrastructure/conditions.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/playbook/infrastructure/conditions.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/playbook/infrastructure/parser.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/playbook/infrastructure/parser.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/tests/test_domain/test_plugin_type_conversion.py" beforeDir="false" afterPath="$PROJECT_DIR$/tests/test_domain/test_plugin_type_conversion.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/tests/test_infrastructure/test_conditional_parsing.py" beforeDir="false" afterPath="$PROJECT_DIR$/tests/test_infrastructure/test_conditional_parsing.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/tests/test_infrastructure/test_conditions.py" beforeDir="false" afterPath="$PROJECT_DIR$/tests/test_infrastructure/test_conditions.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/tests/test_infrastructure/test_parser.py" beforeDir="false" afterPath="$PROJECT_DIR$/tests/test_infrastructure/test_parser.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/tests/test_infrastructure/test_python_plugin.py" beforeDir="false" afterPath="$PROJECT_DIR$/tests/test_infrastructure/test_python_plugin.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/tests/test_service/test_conditional_execution.py" beforeDir="false" afterPath="$PROJECT_DIR$/tests/test_service/test_conditional_execution.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -44,7 +54,7 @@
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
     "SHARE_PROJECT_CONFIGURATION_FILES": "true",
-    "git-widget-placeholder": "main",
+    "git-widget-placeholder": "feat/sugar",
     "last_opened_file_path": "/Users/Q187392/dev/s/private/playbook",
     "node.js.detected.package.eslint": "true",
     "node.js.detected.package.tslint": "true",
@@ -219,6 +229,7 @@
       <workItem from="1747493060514" duration="1480000" />
       <workItem from="1747585183236" duration="981000" />
       <workItem from="1758187886657" duration="17841000" />
+      <workItem from="1759076656935" duration="527000" />
     </task>
     <servers />
   </component>

--- a/src/playbook/infrastructure/conditions.py
+++ b/src/playbook/infrastructure/conditions.py
@@ -1,9 +1,8 @@
 # src/playbook/infrastructure/conditions.py
 """Conditional execution support for workflow nodes."""
 
-import re
 from typing import Dict, List, Any, Optional, Tuple
-from jinja2 import Environment, Template, BaseLoader
+from jinja2 import Environment, BaseLoader
 from ..domain.models import NodeExecution, NodeStatus
 
 
@@ -144,7 +143,7 @@ class ConditionEvaluator:
                     # Try to evaluate as Python expression for numbers/expressions
                     try:
                         return bool(eval(result_lower))
-                    except:
+                    except Exception:
                         # If all else fails, non-empty string is truthy
                         return bool(result_lower)
             else:

--- a/tests/test_domain/test_plugin_type_conversion.py
+++ b/tests/test_domain/test_plugin_type_conversion.py
@@ -2,7 +2,6 @@
 """Tests for plugin parameter type conversion functionality."""
 
 import pytest
-from unittest.mock import Mock
 
 from src.playbook.domain.plugins import (
     Plugin,

--- a/tests/test_infrastructure/test_conditional_parsing.py
+++ b/tests/test_infrastructure/test_conditional_parsing.py
@@ -4,7 +4,6 @@
 import pytest
 import tempfile
 import os
-from datetime import datetime
 
 from src.playbook.infrastructure.parser import RunbookParser
 from src.playbook.infrastructure.variables import VariableManager

--- a/tests/test_infrastructure/test_conditions.py
+++ b/tests/test_infrastructure/test_conditions.py
@@ -3,7 +3,6 @@
 
 import pytest
 from datetime import datetime
-from typing import Dict
 
 from src.playbook.infrastructure.conditions import (
     ConditionalDependency,

--- a/tests/test_infrastructure/test_parser.py
+++ b/tests/test_infrastructure/test_parser.py
@@ -161,3 +161,225 @@ title = "Test" # Missing closing bracket
         """Create a temporary directory for testing."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             yield Path(tmp_dir)
+
+    def test_implicit_linear_dependencies(self, parser, temp_dir):
+        """Test implicit linear dependencies when depends_on is omitted."""
+        content = """
+[runbook]
+title = "Linear Workflow"
+description = "Test linear workflow"
+version = "1.0.0"
+author = "Test Author"
+created_at = "2025-01-20T12:00:00Z"
+
+[step1]
+type = "Command"
+command_name = "echo 'First step'"
+
+[step2]
+type = "Command"
+command_name = "echo 'Second step'"
+
+[step3]
+type = "Command"
+command_name = "echo 'Third step'"
+"""
+        toml_file = temp_dir / "linear.playbook.toml"
+        toml_file.write_text(content)
+
+        runbook = parser.parse(str(toml_file))
+
+        # First step should have no dependencies
+        assert runbook.nodes["step1"].depends_on == []
+
+        # Second step should depend on first
+        assert runbook.nodes["step2"].depends_on == ["step1"]
+
+        # Third step should depend on second
+        assert runbook.nodes["step3"].depends_on == ["step2"]
+
+    def test_string_dependency_normalization(self, parser, temp_dir):
+        """Test that string dependencies are normalized to lists."""
+        content = """
+[runbook]
+title = "String Deps"
+description = "Test string dependencies"
+version = "1.0.0"
+author = "Test Author"
+created_at = "2025-01-20T12:00:00Z"
+
+[step1]
+type = "Command"
+command_name = "echo 'First step'"
+depends_on = []
+
+[step2]
+type = "Command"
+command_name = "echo 'Second step'"
+depends_on = "step1"
+"""
+        toml_file = temp_dir / "string_deps.playbook.toml"
+        toml_file.write_text(content)
+
+        runbook = parser.parse(str(toml_file))
+
+        # step2 should have step1 as dependency (string converted to list)
+        assert runbook.nodes["step2"].depends_on == ["step1"]
+
+    def test_caret_keyword_dependency(self, parser, temp_dir):
+        """Test ^ keyword for previous node dependency."""
+        content = """
+[runbook]
+title = "Caret Dependencies"
+description = "Test caret keyword"
+version = "1.0.0"
+author = "Test Author"
+created_at = "2025-01-20T12:00:00Z"
+
+[step1]
+type = "Command"
+command_name = "echo 'First step'"
+
+[step2]
+type = "Command"
+command_name = "echo 'Second step'"
+depends_on = "^"
+
+[step3]
+type = "Command"
+command_name = "echo 'Third step'"
+depends_on = "^"
+"""
+        toml_file = temp_dir / "caret_deps.playbook.toml"
+        toml_file.write_text(content)
+
+        runbook = parser.parse(str(toml_file))
+
+        # First step should have no dependencies
+        assert runbook.nodes["step1"].depends_on == []
+
+        # step2 should depend on step1 (previous node)
+        assert runbook.nodes["step2"].depends_on == ["step1"]
+
+        # step3 should depend on step2 (previous node)
+        assert runbook.nodes["step3"].depends_on == ["step2"]
+
+    def test_star_keyword_dependency(self, parser, temp_dir):
+        """Test * keyword for all previous nodes dependency."""
+        content = """
+[runbook]
+title = "Star Dependencies"
+description = "Test star keyword"
+version = "1.0.0"
+author = "Test Author"
+created_at = "2025-01-20T12:00:00Z"
+
+[step1]
+type = "Command"
+command_name = "echo 'First step'"
+
+[step2]
+type = "Command"
+command_name = "echo 'Second step'"
+
+[final]
+type = "Command"
+command_name = "echo 'Final step'"
+depends_on = "*"
+"""
+        toml_file = temp_dir / "star_deps.playbook.toml"
+        toml_file.write_text(content)
+
+        runbook = parser.parse(str(toml_file))
+
+        # First step should have no dependencies (implicit)
+        assert runbook.nodes["step1"].depends_on == []
+
+        # Second step should depend on first (implicit)
+        assert runbook.nodes["step2"].depends_on == ["step1"]
+
+        # Final step should depend on all previous nodes
+        assert runbook.nodes["final"].depends_on == ["step1", "step2"]
+
+    def test_mixed_keywords_in_list(self, parser, temp_dir):
+        """Test mixing special keywords with regular dependencies in a list."""
+        content = """
+[runbook]
+title = "Mixed Dependencies"
+description = "Test mixed keywords"
+version = "1.0.0"
+author = "Test Author"
+created_at = "2025-01-20T12:00:00Z"
+
+[step1]
+type = "Command"
+command_name = "echo 'First step'"
+
+[step2]
+type = "Command"
+command_name = "echo 'Second step'"
+
+[other]
+type = "Command"
+command_name = "echo 'Other step'"
+depends_on = []
+
+[final]
+type = "Command"
+command_name = "echo 'Final step'"
+depends_on = ["^", "step1"]
+"""
+        toml_file = temp_dir / "mixed_deps.playbook.toml"
+        toml_file.write_text(content)
+
+        runbook = parser.parse(str(toml_file))
+
+        # Final step should depend on previous node (other) and step1
+        expected_deps = ["other", "step1"]
+        assert sorted(runbook.nodes["final"].depends_on) == sorted(expected_deps)
+
+    def test_caret_keyword_first_node(self, parser, temp_dir):
+        """Test ^ keyword on first node (should result in no dependencies)."""
+        content = """
+[runbook]
+title = "First Node Caret"
+description = "Test caret on first node"
+version = "1.0.0"
+author = "Test Author"
+created_at = "2025-01-20T12:00:00Z"
+
+[first]
+type = "Command"
+command_name = "echo 'First step'"
+depends_on = "^"
+"""
+        toml_file = temp_dir / "first_caret.playbook.toml"
+        toml_file.write_text(content)
+
+        runbook = parser.parse(str(toml_file))
+
+        # First node with ^ should have no dependencies
+        assert runbook.nodes["first"].depends_on == []
+
+    def test_star_keyword_first_node(self, parser, temp_dir):
+        """Test * keyword on first node (should result in no dependencies)."""
+        content = """
+[runbook]
+title = "First Node Star"
+description = "Test star on first node"
+version = "1.0.0"
+author = "Test Author"
+created_at = "2025-01-20T12:00:00Z"
+
+[first]
+type = "Command"
+command_name = "echo 'First step'"
+depends_on = "*"
+"""
+        toml_file = temp_dir / "first_star.playbook.toml"
+        toml_file.write_text(content)
+
+        runbook = parser.parse(str(toml_file))
+
+        # First node with * should have no dependencies
+        assert runbook.nodes["first"].depends_on == []

--- a/tests/test_infrastructure/test_python_plugin.py
+++ b/tests/test_infrastructure/test_python_plugin.py
@@ -2,7 +2,6 @@
 """Tests for the Python plugin."""
 
 import pytest
-from unittest.mock import patch, Mock
 
 from src.playbook.infrastructure.plugins.python_plugin import PythonPlugin
 from src.playbook.domain.plugins import PluginExecutionError

--- a/tests/test_service/test_conditional_execution.py
+++ b/tests/test_service/test_conditional_execution.py
@@ -1,9 +1,8 @@
 # tests/test_service/test_conditional_execution.py
 """Integration tests for conditional node execution."""
 
-import pytest
 from datetime import datetime
-from unittest.mock import Mock, MagicMock
+from unittest.mock import Mock
 
 from src.playbook.service.engine import RunbookEngine
 from src.playbook.domain.models import (


### PR DESCRIPTION
## Summary

This PR introduces syntactic sugar to reduce verbosity when defining linear workflows, addressing the tedium of explicitly specifying `depends_on` for sequential steps.

## Changes

### Implicit Linear Dependencies
- When `depends_on` is omitted, nodes automatically depend on the previous node in declaration order
- First node defaults to no dependencies
- Maintains full backward compatibility with explicit dependencies

### Simplified Single Dependencies  
- Accept string values instead of lists for single dependencies
- `depends_on = "step1"` instead of `depends_on = ["step1"]`

### Special Keywords
- `depends_on = "^"` - Depend on the previous node (explicit version of implicit behavior)
- `depends_on = "*"` - Depend on all previous nodes

## Example

Before:
```toml
[step1]
type = "Command"
command_name = "echo 'First'"
depends_on = []

[step2] 
type = "Command"
command_name = "echo 'Second'"
depends_on = ["step1"]

[step3]
type = "Command" 
command_name = "echo 'Third'"
depends_on = ["step2"]
```

After:
```toml
[step1]
type = "Command"
command_name = "echo 'First'"

[step2]
type = "Command"
command_name = "echo 'Second'"

[step3]
type = "Command"
command_name = "echo 'Third'"
```

This change significantly improves the user experience for defining common linear workflows while preserving all existing functionality.