### PR TITLE
feat: improve workflow state management and resumability

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -7,15 +7,14 @@
     <list default="true" id="5a384825-87f7-4752-bb95-dcf8d7a51e56" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/README.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/llm_workflow_generator_prompt.md" beforeDir="false" afterPath="$PROJECT_DIR$/llm_workflow_generator_prompt.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/playbook/cli/commands/info.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/playbook/cli/commands/info.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/playbook/cli/commands/run.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/playbook/cli/commands/run.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/playbook/cli/main.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/playbook/cli/main.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/playbook/domain/models.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/playbook/domain/models.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/playbook/infrastructure/conditions.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/playbook/infrastructure/conditions.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/playbook/infrastructure/parser.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/playbook/infrastructure/parser.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/tests/test_domain/test_plugin_type_conversion.py" beforeDir="false" afterPath="$PROJECT_DIR$/tests/test_domain/test_plugin_type_conversion.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/tests/test_infrastructure/test_conditional_parsing.py" beforeDir="false" afterPath="$PROJECT_DIR$/tests/test_infrastructure/test_conditional_parsing.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/tests/test_infrastructure/test_conditions.py" beforeDir="false" afterPath="$PROJECT_DIR$/tests/test_infrastructure/test_conditions.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/tests/test_infrastructure/test_parser.py" beforeDir="false" afterPath="$PROJECT_DIR$/tests/test_infrastructure/test_parser.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/tests/test_infrastructure/test_python_plugin.py" beforeDir="false" afterPath="$PROJECT_DIR$/tests/test_infrastructure/test_python_plugin.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/tests/test_service/test_conditional_execution.py" beforeDir="false" afterPath="$PROJECT_DIR$/tests/test_service/test_conditional_execution.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/playbook/infrastructure/statistics.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/playbook/infrastructure/statistics.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/playbook/service/engine.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/playbook/service/engine.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/tests/test_service/test_engine.py" beforeDir="false" afterPath="$PROJECT_DIR$/tests/test_service/test_engine.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -37,39 +36,39 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "ModuleVcsDetector.initialDetectionPerformed": "true",
-    "Python tests.Python tests for test_engine.TestRunbookEngine.test_has_cycles_whenNoCyclesExist_thenReturnsFalse.executor": "Run",
-    "Python tests.Python tests for test_engine.TestRunbookEngine.test_has_cycles_whenNonExistentDependency_thenRaisesKeyError.executor": "Run",
-    "Python tests.Python tests for test_engine.TestRunbookEngine.test_resume_node_execution_whenManualNode_thenExecutesManualNode.executor": "Run",
-    "Python tests.Python tests for test_engine.TestRunbookEngine.test_update_run_status_whenAllNodesOK_thenRunStatusOK.executor": "Run",
-    "Python tests.Python tests for test_engine.TestRunbookEngine.test_update_run_status_whenCriticalNodeFails_thenRunStatusNOK.executor": "Run",
-    "Python tests.Python tests for test_engine.TestRunbookEngine.test_validate_whenNonExistentDependency_thenReturnsError.executor": "Run",
-    "Python tests.Python tests in test_engine.py.executor": "Run",
-    "Python.cli.executor": "Run",
-    "Python.playbook.infrastructure.cli experimenting.executor": "Debug",
-    "Python.playbook.infrastructure.cli run.executor": "Debug",
-    "Python.playbook.infrastructure.cli.executor": "Run",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "RunOnceActivity.git.unshallow": "true",
-    "SHARE_PROJECT_CONFIGURATION_FILES": "true",
-    "git-widget-placeholder": "feat/sugar",
-    "last_opened_file_path": "/Users/Q187392/dev/s/private/playbook",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_package_manager_path": "npm",
-    "settings.editor.selected.configurable": "http.proxy",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
+    &quot;Python tests.Python tests for test_engine.TestRunbookEngine.test_has_cycles_whenNoCyclesExist_thenReturnsFalse.executor&quot;: &quot;Run&quot;,
+    &quot;Python tests.Python tests for test_engine.TestRunbookEngine.test_has_cycles_whenNonExistentDependency_thenRaisesKeyError.executor&quot;: &quot;Run&quot;,
+    &quot;Python tests.Python tests for test_engine.TestRunbookEngine.test_resume_node_execution_whenManualNode_thenExecutesManualNode.executor&quot;: &quot;Run&quot;,
+    &quot;Python tests.Python tests for test_engine.TestRunbookEngine.test_update_run_status_whenAllNodesOK_thenRunStatusOK.executor&quot;: &quot;Run&quot;,
+    &quot;Python tests.Python tests for test_engine.TestRunbookEngine.test_update_run_status_whenCriticalNodeFails_thenRunStatusNOK.executor&quot;: &quot;Run&quot;,
+    &quot;Python tests.Python tests for test_engine.TestRunbookEngine.test_validate_whenNonExistentDependency_thenReturnsError.executor&quot;: &quot;Run&quot;,
+    &quot;Python tests.Python tests in test_engine.py.executor&quot;: &quot;Run&quot;,
+    &quot;Python.cli.executor&quot;: &quot;Run&quot;,
+    &quot;Python.playbook.infrastructure.cli experimenting.executor&quot;: &quot;Debug&quot;,
+    &quot;Python.playbook.infrastructure.cli run.executor&quot;: &quot;Debug&quot;,
+    &quot;Python.playbook.infrastructure.cli.executor&quot;: &quot;Run&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
+    &quot;SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;main&quot;,
+    &quot;last_opened_file_path&quot;: &quot;/Users/Q187392/dev/s/private/playbook&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;http.proxy&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   },
-  "keyToStringList": {
-    "com.intellij.ide.scratch.ScratchImplUtil$2/New Scratch File": [
-      "JSON"
+  &quot;keyToStringList&quot;: {
+    &quot;com.intellij.ide.scratch.ScratchImplUtil$2/New Scratch File&quot;: [
+      &quot;JSON&quot;
     ]
   }
-}]]></component>
+}</component>
   <component name="RecentsManager">
     <key name="CopyFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/src/playbook/presentation/cli" />
@@ -229,7 +228,8 @@
       <workItem from="1747493060514" duration="1480000" />
       <workItem from="1747585183236" duration="981000" />
       <workItem from="1758187886657" duration="17841000" />
-      <workItem from="1759076656935" duration="527000" />
+      <workItem from="1759076656935" duration="1837000" />
+      <workItem from="1759910542383" duration="957000" />
     </task>
     <servers />
   </component>
@@ -252,7 +252,7 @@
       <breakpoints>
         <line-breakpoint enabled="true" suspend="THREAD" type="python-line">
           <url>file://$PROJECT_DIR$/src/playbook/service/engine.py</url>
-          <line>592</line>
+          <line>596</line>
           <option name="timeStamp" value="4" />
         </line-breakpoint>
         <line-breakpoint enabled="true" suspend="THREAD" type="python-line">

--- a/src/playbook/cli/commands/info.py
+++ b/src/playbook/cli/commands/info.py
@@ -58,10 +58,11 @@ def info(
                 "NOK",
                 "Running",
                 "Aborted",
+                "Last Run ID",
                 "Latest Run",
             )
 
-            for workflow_name, stats in workflow_stats.items():
+            for workflow_name, stats in sorted(workflow_stats.items(), key=lambda x: x[0].lower()):
                 status_counts = stats["status_counts"]
                 ok_count = status_counts.get("ok", 0)
                 nok_count = status_counts.get("nok", 0)
@@ -75,6 +76,7 @@ def info(
                     str(nok_count),
                     str(running_count),
                     str(aborted_count),
+                    str(stats["latest_run_id"]) if stats["latest_run_id"] is not None else "N/A",
                     stats["latest_run"] or "N/A",
                 )
 
@@ -91,7 +93,7 @@ def info(
                 "Workflow", "Node", "OK", "NOK", "Skipped", "Pending", "Running"
             )
 
-            for key, stats in node_stats.items():
+            for key, stats in sorted(node_stats.items(), key=lambda x: x[0].lower()):
                 status_counts = stats["status_counts"]
 
                 table.add_row(

--- a/src/playbook/cli/commands/set_status.py
+++ b/src/playbook/cli/commands/set_status.py
@@ -1,0 +1,167 @@
+# src/playbook/cli/commands/set_status.py
+"""Set status command implementation."""
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.prompt import Confirm
+
+from ..common import console, get_engine, handle_error_and_exit
+from ...domain.models import RunStatus
+from ...domain.exceptions import DatabaseError, ParseError
+from ...infrastructure.parser import RunbookParser
+
+
+def set_status(
+    ctx: typer.Context,
+    file: Path = typer.Argument(..., help="Runbook file path"),
+    run_id: int = typer.Argument(..., help="Run ID to update"),
+    new_status: str = typer.Argument(..., help="New status (RUNNING, OK, NOK, ABORTED)"),
+    state_path: Optional[str] = typer.Option(
+        None, "--state-path", help="State database path"
+    ),
+    force: bool = typer.Option(
+        False, "--force", "-f", help="Skip confirmation prompts"
+    ),
+) -> None:
+    """Manually set workflow run status
+
+    This command allows you to manually change the status of a workflow run.
+    Common use cases:
+    - Fix orphaned RUNNING workflows after system crash
+    - Manually mark workflows as completed or failed
+    - Reset workflow state for testing
+
+    WARNING: This command directly modifies workflow state. Use with caution.
+    """
+    try:
+        # Parse runbook to get workflow name
+        parser = RunbookParser()
+        try:
+            runbook = parser.parse(str(file))
+        except FileNotFoundError:
+            raise ParseError(
+                f"Runbook file not found: {file}",
+                suggestion="Check the file path and ensure the file exists",
+            )
+        except Exception as e:
+            raise ParseError(
+                f"Failed to parse runbook: {str(e)}",
+                context={"file": str(file)},
+                suggestion="Check the TOML syntax and ensure all required fields are present",
+            )
+
+        workflow_name = runbook.title
+
+        # Validate new status
+        try:
+            new_status_enum = RunStatus(new_status.lower())
+        except ValueError:
+            valid_statuses = ", ".join([s.value.upper() for s in RunStatus])
+            console.print(
+                f"[bold red]Invalid status: {new_status}[/bold red]\n"
+                f"Valid statuses: {valid_statuses}"
+            )
+            raise typer.Exit(code=1)
+
+        # Get engine and current run info
+        engine = get_engine(state_path)
+
+        try:
+            run_info = engine.run_repo.get_run(workflow_name, run_id)
+        except Exception as e:
+            raise DatabaseError(
+                f"Failed to retrieve run {run_id} for workflow '{workflow_name}': {str(e)}",
+                context={"workflow": workflow_name, "run_id": run_id},
+                suggestion="Check that the run ID exists for this workflow",
+            )
+
+        current_status = run_info.status
+
+        # Display current state
+        console.print(f"\n[bold]Workflow:[/bold] {workflow_name}")
+        console.print(f"[bold]Run ID:[/bold] {run_id}")
+
+        current_color = _get_status_color(current_status)
+        new_color = _get_status_color(new_status_enum)
+
+        console.print(
+            f"[bold]Current status:[/bold] [{current_color}]{current_status.value.upper()}[/{current_color}]"
+        )
+        console.print(
+            f"[bold]New status:[/bold] [{new_color}]{new_status_enum.value.upper()}[/{new_color}]"
+        )
+
+        # Safety checks
+        if current_status == new_status_enum:
+            console.print(f"\n[yellow]Status is already {new_status_enum.value.upper()}. No change needed.[/yellow]")
+            return
+
+        warnings = []
+
+        # Warn if changing from terminal state to non-terminal
+        terminal_states = {RunStatus.OK, RunStatus.NOK}
+        non_terminal_states = {RunStatus.RUNNING, RunStatus.ABORTED}
+
+        if current_status in terminal_states and new_status_enum in non_terminal_states:
+            warnings.append(
+                f"⚠️  Changing from terminal state {current_status.value.upper()} to "
+                f"non-terminal state {new_status_enum.value.upper()}. This is unusual."
+            )
+
+        # Warn if setting to RUNNING
+        if new_status_enum == RunStatus.RUNNING:
+            warnings.append(
+                "⚠️  Setting status to RUNNING may interfere with workflow execution. "
+                "Ensure no other process is running this workflow."
+            )
+
+        # Display warnings
+        if warnings:
+            console.print()
+            for warning in warnings:
+                console.print(f"[bold yellow]{warning}[/bold yellow]")
+
+        # Confirmation prompt
+        if not force:
+            console.print()
+            confirmed = Confirm.ask(
+                f"Set status of {workflow_name}#{run_id} from "
+                f"{current_status.value.upper()} to {new_status_enum.value.upper()}?",
+                default=False
+            )
+
+            if not confirmed:
+                console.print("[yellow]Operation cancelled.[/yellow]")
+                raise typer.Exit(code=0)
+
+        # Update status
+        run_info.status = new_status_enum
+        engine.run_repo.update_run(run_info)
+
+        console.print(
+            f"\n[bold green]✓[/bold green] Status updated to "
+            f"[{new_color}]{new_status_enum.value.upper()}[/{new_color}]"
+        )
+
+        # Provide helpful next steps
+        if new_status_enum == RunStatus.ABORTED:
+            console.print(
+                f"\n[dim]You can now resume this workflow with:[/dim]\n"
+                f"  playbook resume {file} {run_id}"
+            )
+
+    except Exception as e:
+        handle_error_and_exit(e, "Set status", ctx.params.get("verbose", False))
+
+
+def _get_status_color(status: RunStatus) -> str:
+    """Get Rich color for status display."""
+    color_map = {
+        RunStatus.OK: "green",
+        RunStatus.NOK: "red",
+        RunStatus.RUNNING: "blue",
+        RunStatus.ABORTED: "yellow",
+    }
+    return color_map.get(status, "white")

--- a/src/playbook/cli/main.py
+++ b/src/playbook/cli/main.py
@@ -11,6 +11,7 @@ from .commands.config import config_cmd
 from .commands.create import create
 from .commands.info import info
 from .commands.run import run, resume
+from .commands.set_status import set_status
 from .commands.show import show
 from .commands.validate import validate
 from .commands.version import print_version
@@ -33,6 +34,7 @@ app.command()(validate)
 app.command()(view_dag)
 app.command()(run)
 app.command()(resume)
+app.command("set-status", help="Manually set workflow run status")(set_status)
 app.command()(info)
 app.command()(show)
 app.command("version", help="Show version", hidden=True)(print_version)

--- a/src/playbook/domain/models.py
+++ b/src/playbook/domain/models.py
@@ -44,14 +44,14 @@ class BaseNode(BaseModel):
     skip: bool = False
     when: str = "true"  # Conditional execution clause, defaults to always execute
 
-    @model_validator(mode='before')
+    @model_validator(mode="before")
     @classmethod
     def normalize_depends_on(cls, values: Any) -> Any:
         """Normalize depends_on to always be a list internally."""
-        if isinstance(values, dict) and 'depends_on' in values:
-            depends_on = values['depends_on']
+        if isinstance(values, dict) and "depends_on" in values:
+            depends_on = values["depends_on"]
             if isinstance(depends_on, str):
-                values['depends_on'] = [depends_on] if depends_on else []
+                values["depends_on"] = [depends_on] if depends_on else []
         return values
 
 

--- a/src/playbook/infrastructure/statistics.py
+++ b/src/playbook/infrastructure/statistics.py
@@ -57,7 +57,7 @@ class SQLiteStatisticsRepository(StatisticsRepository):
                 # Get latest run
                 latest_cursor = conn.execute(
                     """
-                    SELECT start_time, status
+                    SELECT run_id, start_time, status
                     FROM runs
                     WHERE workflow_name = ?
                     ORDER BY run_id DESC LIMIT 1
@@ -69,6 +69,7 @@ class SQLiteStatisticsRepository(StatisticsRepository):
                 result[workflow_name] = {
                     "total_runs": workflow["run_count"],
                     "status_counts": status_counts,
+                    "latest_run_id": latest["run_id"] if latest else None,
                     "latest_run": latest["start_time"] if latest else None,
                     "latest_status": latest["status"] if latest else None,
                 }

--- a/src/playbook/service/engine.py
+++ b/src/playbook/service/engine.py
@@ -279,9 +279,13 @@ class RunbookEngine:
         # Get existing run
         run_info = self.run_repo.get_run(runbook.title, run_id)
 
-        # Verify run can be resumed (not OK or NOK)
-        if run_info.status not in [RunStatus.RUNNING, RunStatus.ABORTED]:
-            raise ValueError(f"Cannot resume run with status {run_info.status}")
+        # Only aborted workflows can be resumed
+        if run_info.status != RunStatus.ABORTED:
+            raise ValueError(
+                f"Cannot resume run with status '{run_info.status}'. "
+                f"Only ABORTED workflows can be resumed. "
+                f"NOK workflows require a new run."
+            )
 
         # Update run status
         run_info.status = RunStatus.RUNNING

--- a/tests/test_cli/test_commands/test_set_status.py
+++ b/tests/test_cli/test_commands/test_set_status.py
@@ -1,0 +1,314 @@
+# tests/test_cli/test_commands/test_set_status.py
+"""Tests for the set-status command."""
+
+from datetime import datetime, timezone
+from unittest.mock import patch, Mock
+
+from playbook.cli.main import app
+from playbook.domain.models import RunStatus, RunInfo, TriggerType
+
+
+class TestSetStatusCommand:
+    """Test cases for the set-status command."""
+
+    @patch("playbook.cli.commands.set_status.RunbookParser")
+    @patch("playbook.cli.commands.set_status.get_engine")
+    @patch("playbook.cli.commands.set_status.Confirm.ask")
+    def test_set_status_when_valid_then_updates_status(
+        self, mock_confirm, mock_get_engine, mock_parser_class, cli_runner, temp_toml_file
+    ):
+        """Test successful status update."""
+        # Mock parser
+        mock_parser = Mock()
+        mock_runbook = Mock()
+        mock_runbook.title = "Test Workflow"
+        mock_parser.parse.return_value = mock_runbook
+        mock_parser_class.return_value = mock_parser
+
+        # Mock engine and run info
+        mock_engine = Mock()
+        run_info = RunInfo(
+            workflow_name="Test Workflow",
+            run_id=42,
+            start_time=datetime.now(timezone.utc),
+            status=RunStatus.RUNNING,
+            trigger=TriggerType.RUN,
+        )
+        mock_engine.run_repo.get_run.return_value = run_info
+        mock_get_engine.return_value = mock_engine
+
+        # Mock confirmation
+        mock_confirm.return_value = True
+
+        result = cli_runner.invoke(
+            app, ["set-status", temp_toml_file, "42", "aborted"]
+        )
+
+        assert result.exit_code == 0
+        assert "Status updated to ABORTED" in result.output
+        mock_engine.run_repo.update_run.assert_called_once()
+
+        # Verify status was changed
+        updated_run_info = mock_engine.run_repo.update_run.call_args[0][0]
+        assert updated_run_info.status == RunStatus.ABORTED
+
+    @patch("playbook.cli.commands.set_status.RunbookParser")
+    @patch("playbook.cli.commands.set_status.get_engine")
+    def test_set_status_when_invalid_status_then_shows_error(
+        self, mock_get_engine, mock_parser_class, cli_runner, temp_toml_file
+    ):
+        """Test invalid status string."""
+        # Mock parser
+        mock_parser = Mock()
+        mock_runbook = Mock()
+        mock_runbook.title = "Test Workflow"
+        mock_parser.parse.return_value = mock_runbook
+        mock_parser_class.return_value = mock_parser
+
+        result = cli_runner.invoke(
+            app, ["set-status", temp_toml_file, "42", "invalid_status"]
+        )
+
+        assert result.exit_code == 1
+        assert "Invalid status" in result.output
+        assert "Valid statuses" in result.output
+
+    @patch("playbook.cli.commands.set_status.RunbookParser")
+    @patch("playbook.cli.commands.set_status.get_engine")
+    def test_set_status_when_run_not_found_then_shows_error(
+        self, mock_get_engine, mock_parser_class, cli_runner, temp_toml_file
+    ):
+        """Test non-existent run_id."""
+        # Mock parser
+        mock_parser = Mock()
+        mock_runbook = Mock()
+        mock_runbook.title = "Test Workflow"
+        mock_parser.parse.return_value = mock_runbook
+        mock_parser_class.return_value = mock_parser
+
+        # Mock engine to raise error
+        mock_engine = Mock()
+        mock_engine.run_repo.get_run.side_effect = ValueError("Run not found")
+        mock_get_engine.return_value = mock_engine
+
+        result = cli_runner.invoke(
+            app, ["set-status", temp_toml_file, "999", "aborted"]
+        )
+
+        assert result.exit_code != 0
+        assert "DatabaseError" in result.output
+
+    @patch("playbook.cli.commands.set_status.RunbookParser")
+    @patch("playbook.cli.commands.set_status.get_engine")
+    @patch("playbook.cli.commands.set_status.Confirm.ask")
+    def test_set_status_when_terminal_to_nonterminal_then_warns(
+        self, mock_confirm, mock_get_engine, mock_parser_class, cli_runner, temp_toml_file
+    ):
+        """Test warning when changing from terminal to non-terminal state."""
+        # Mock parser
+        mock_parser = Mock()
+        mock_runbook = Mock()
+        mock_runbook.title = "Test Workflow"
+        mock_parser.parse.return_value = mock_runbook
+        mock_parser_class.return_value = mock_parser
+
+        # Mock engine with completed run
+        mock_engine = Mock()
+        run_info = RunInfo(
+            workflow_name="Test Workflow",
+            run_id=42,
+            start_time=datetime.now(timezone.utc),
+            status=RunStatus.OK,  # Terminal state
+            trigger=TriggerType.RUN,
+        )
+        mock_engine.run_repo.get_run.return_value = run_info
+        mock_get_engine.return_value = mock_engine
+
+        # Mock confirmation
+        mock_confirm.return_value = True
+
+        result = cli_runner.invoke(
+            app, ["set-status", temp_toml_file, "42", "running"]
+        )
+
+        assert result.exit_code == 0
+        assert "⚠️" in result.output
+        assert "terminal state" in result.output
+
+    @patch("playbook.cli.commands.set_status.RunbookParser")
+    @patch("playbook.cli.commands.set_status.get_engine")
+    def test_set_status_when_force_then_skips_confirmation(
+        self, mock_get_engine, mock_parser_class, cli_runner, temp_toml_file
+    ):
+        """Test force flag skips confirmation."""
+        # Mock parser
+        mock_parser = Mock()
+        mock_runbook = Mock()
+        mock_runbook.title = "Test Workflow"
+        mock_parser.parse.return_value = mock_runbook
+        mock_parser_class.return_value = mock_parser
+
+        # Mock engine and run info
+        mock_engine = Mock()
+        run_info = RunInfo(
+            workflow_name="Test Workflow",
+            run_id=42,
+            start_time=datetime.now(timezone.utc),
+            status=RunStatus.RUNNING,
+            trigger=TriggerType.RUN,
+        )
+        mock_engine.run_repo.get_run.return_value = run_info
+        mock_get_engine.return_value = mock_engine
+
+        result = cli_runner.invoke(
+            app, ["set-status", temp_toml_file, "42", "aborted", "--force"]
+        )
+
+        assert result.exit_code == 0
+        assert "Status updated to ABORTED" in result.output
+        mock_engine.run_repo.update_run.assert_called_once()
+
+    @patch("playbook.cli.commands.set_status.RunbookParser")
+    @patch("playbook.cli.commands.set_status.get_engine")
+    @patch("playbook.cli.commands.set_status.Confirm.ask")
+    def test_set_status_case_insensitive(
+        self, mock_confirm, mock_get_engine, mock_parser_class, cli_runner, temp_toml_file
+    ):
+        """Test case-insensitive status handling."""
+        # Mock parser
+        mock_parser = Mock()
+        mock_runbook = Mock()
+        mock_runbook.title = "Test Workflow"
+        mock_parser.parse.return_value = mock_runbook
+        mock_parser_class.return_value = mock_parser
+
+        # Mock engine and run info
+        mock_engine = Mock()
+        run_info = RunInfo(
+            workflow_name="Test Workflow",
+            run_id=42,
+            start_time=datetime.now(timezone.utc),
+            status=RunStatus.RUNNING,
+            trigger=TriggerType.RUN,
+        )
+        mock_engine.run_repo.get_run.return_value = run_info
+        mock_get_engine.return_value = mock_engine
+
+        # Mock confirmation
+        mock_confirm.return_value = True
+
+        # Test with different cases
+        for status_str in ["ABORTED", "aborted", "Aborted"]:
+            result = cli_runner.invoke(
+                app, ["set-status", temp_toml_file, "42", status_str]
+            )
+
+            assert result.exit_code == 0
+
+    @patch("playbook.cli.commands.set_status.RunbookParser")
+    @patch("playbook.cli.commands.set_status.get_engine")
+    @patch("playbook.cli.commands.set_status.Confirm.ask")
+    def test_set_status_when_user_cancels_then_exits(
+        self, mock_confirm, mock_get_engine, mock_parser_class, cli_runner, temp_toml_file
+    ):
+        """Test user canceling the operation."""
+        # Mock parser
+        mock_parser = Mock()
+        mock_runbook = Mock()
+        mock_runbook.title = "Test Workflow"
+        mock_parser.parse.return_value = mock_runbook
+        mock_parser_class.return_value = mock_parser
+
+        # Mock engine and run info
+        mock_engine = Mock()
+        run_info = RunInfo(
+            workflow_name="Test Workflow",
+            run_id=42,
+            start_time=datetime.now(timezone.utc),
+            status=RunStatus.RUNNING,
+            trigger=TriggerType.RUN,
+        )
+        mock_engine.run_repo.get_run.return_value = run_info
+        mock_get_engine.return_value = mock_engine
+
+        # Mock confirmation to return False
+        mock_confirm.return_value = False
+
+        result = cli_runner.invoke(
+            app, ["set-status", temp_toml_file, "42", "aborted"]
+        )
+
+        # User cancellation is not an error, but we exit gracefully
+        assert result.exit_code in [0, 1]  # Typer may return 0 or 1 for graceful exit
+        assert "Operation cancelled" in result.output
+        mock_engine.run_repo.update_run.assert_not_called()
+
+    @patch("playbook.cli.commands.set_status.RunbookParser")
+    @patch("playbook.cli.commands.set_status.get_engine")
+    def test_set_status_when_same_status_then_no_change(
+        self, mock_get_engine, mock_parser_class, cli_runner, temp_toml_file
+    ):
+        """Test setting to same status."""
+        # Mock parser
+        mock_parser = Mock()
+        mock_runbook = Mock()
+        mock_runbook.title = "Test Workflow"
+        mock_parser.parse.return_value = mock_runbook
+        mock_parser_class.return_value = mock_parser
+
+        # Mock engine and run info
+        mock_engine = Mock()
+        run_info = RunInfo(
+            workflow_name="Test Workflow",
+            run_id=42,
+            start_time=datetime.now(timezone.utc),
+            status=RunStatus.ABORTED,  # Already aborted
+            trigger=TriggerType.RUN,
+        )
+        mock_engine.run_repo.get_run.return_value = run_info
+        mock_get_engine.return_value = mock_engine
+
+        result = cli_runner.invoke(
+            app, ["set-status", temp_toml_file, "42", "aborted"]
+        )
+
+        assert result.exit_code == 0
+        assert "Status is already ABORTED" in result.output
+        assert "No change needed" in result.output
+        mock_engine.run_repo.update_run.assert_not_called()
+
+    @patch("playbook.cli.commands.set_status.RunbookParser")
+    @patch("playbook.cli.commands.set_status.get_engine")
+    @patch("playbook.cli.commands.set_status.Confirm.ask")
+    def test_set_status_when_aborted_then_shows_resume_hint(
+        self, mock_confirm, mock_get_engine, mock_parser_class, cli_runner, temp_toml_file
+    ):
+        """Test helpful hint after setting to ABORTED."""
+        # Mock parser
+        mock_parser = Mock()
+        mock_runbook = Mock()
+        mock_runbook.title = "Test Workflow"
+        mock_parser.parse.return_value = mock_runbook
+        mock_parser_class.return_value = mock_parser
+
+        # Mock engine and run info
+        mock_engine = Mock()
+        run_info = RunInfo(
+            workflow_name="Test Workflow",
+            run_id=42,
+            start_time=datetime.now(timezone.utc),
+            status=RunStatus.RUNNING,
+            trigger=TriggerType.RUN,
+        )
+        mock_engine.run_repo.get_run.return_value = run_info
+        mock_get_engine.return_value = mock_engine
+
+        # Mock confirmation
+        mock_confirm.return_value = True
+
+        result = cli_runner.invoke(
+            app, ["set-status", temp_toml_file, "42", "aborted"]
+        )
+
+        assert result.exit_code == 0
+        assert "playbook resume" in result.output


### PR DESCRIPTION
This commit introduces several enhancements to workflow state management:

Workflow Resume Behavior:
- Restrict resume to ABORTED workflows only (not RUNNING, OK, or NOK)
- NOK workflows now require a fresh run instead of resume
- Add KeyboardInterrupt (CTRL-C) handling to mark workflows as ABORTED
- Auto-detect latest aborted run when no run_id specified in resume
- Update resume validation with clearer error messages

New set-status Command:
- Add manual workflow status modification command
- Support for fixing orphaned workflows (RUNNING after crashes)

Info Command Enhancement:
- Add "Last Run ID" column to workflow statistics table
- Show latest run_id alongside timestamp for easier resume operations